### PR TITLE
Fixed mathematics of "Go X% way to ..."

### DIFF
--- a/code/final_face_slider_tool.py
+++ b/code/final_face_slider_tool.py
@@ -462,12 +462,12 @@ def go_to_celeb(c):
         slider_settings = celebSliders[celeb_choice]
         if approach_settings[1] == 1:
             for i in range(DENSE_SIZE):
-                settings[i] += slider_settings[i] - settings[i] * approach_settings[0]
+                settings[i] += (slider_settings[i] - settings[i]) * approach_settings[0]
         else:
             transitionKeyFrames[0] = settings.copy()
             transitionKeyFrames[1] = settings.copy()
             for i in range(DENSE_SIZE):
-                transitionKeyFrames[1, i] += slider_settings[i] - settings[i] * approach_settings[0]
+                transitionKeyFrames[1, i] += (slider_settings[i] - settings[i]) * approach_settings[0]
             transitionTimes[0] = frameTimer - 1
             transitionTimes[1] = frameTimer - 1 + 100 * (1 - approach_settings[1])  # really bad magic numbers oh well
     return 0


### PR DESCRIPTION
The previous version was not mathematically correct.

Previously, when you entered the settings for "Cardi B", set the slider to 50% and gave "Justin Bieber" as input, you would get another result compared to first entering "Justin Bieber", setting to 50% and then "Cardi B", thus indicating that there was a problem. I fixed it using two simple parentheses. 

If you want to predict the baby of two people using this tool, it should be now be correct instead of leaning towards the second name entered.