### PR TITLE
Update tensorboard and tensorflow dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,8 @@ PyWavelets==1.0.1
 scikit-image==0.14.2
 scipy==1.2.1
 six==1.12.0
-tensorboard==1.12.2
-tensorflow==1.12.0
+tensorboard==1.15.0
+tensorflow==1.15.0
 termcolor==1.1.0
 toolz==0.9.0
 Werkzeug==0.14.1


### PR DESCRIPTION
This change updates tensorboard from 1.12.2 to 1.15.0 and tensorflow
from 1.12.0 to 1.15.0.  This was done because the command to install
dependencies with the old version failed because they are no longer
available.